### PR TITLE
fixed wrong frame size in case frame size equals source buffer size

### DIFF
--- a/C/yahdlc.c
+++ b/C/yahdlc.c
@@ -154,6 +154,15 @@ int yahdlc_get_data_with_state(yahdlc_state_t *state, yahdlc_control_t *control,
         }
 
         state->end_index = state->src_index;
+
+        // If we have a frame with a size that equals the src_len (source buffer size),
+        // then 'i' ends up being one less than the frame size,
+        // and we therefore report a wrong frame size in the return value.
+        // Therefore, add 1 to return the correct frame size.
+        if (state->end_index + 1 == src_len)
+        {
+          i++;
+        }
         break;
       } else if (src[i] == YAHDLC_CONTROL_ESCAPE) {
         state->control_escape = 1;


### PR DESCRIPTION
If we have a frame with a size that equals the src_len (source buffer size), then the returned frame size from `yahdlc_get_data_with_state` ends up being one less than the frame size.

Therefore, add 1 to return the correct frame size.